### PR TITLE
feat: harden html rendering and add project docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Thanks for contributing to this open source project.
+
+## Ground Rules
+
+- Keep changes focused and easy to review.
+- Prefer fixes at the root cause over one-off patches.
+- Update documentation when behavior, permissions, release packaging, or compliance expectations change.
+- Do not add features intended to facilitate misuse, policy evasion, infringement, unauthorized access, or abusive automation.
+- Preserve the project's responsible-use, trademark, and platform-compliance language in [LEGAL.md](LEGAL.md) and [README.md](README.md).
+
+## Development Setup
+
+```bash
+npm ci
+npm run setup:hooks
+```
+
+## Validation
+
+Run the checks relevant to your change before opening a pull request:
+
+```bash
+npm run build:prod
+npm run buildff:prod
+npm run verify:versions
+```
+
+If your change affects Firefox packaging or permissions, also validate the built Firefox artifact as needed.
+
+## Pull Requests
+
+- Use a short, descriptive title.
+- Explain the behavior change, not just the code diff.
+- Include screenshots or short recordings for UI changes when practical.
+- Call out any manifest, permissions, or release-artifact changes explicitly.
+- Note any follow-up work or known limitations.
+
+## Release Notes And Artifacts
+
+- Pushes to `main` trigger the GitHub release workflow in `.github/workflows/release-on-main.yml`.
+- That workflow publishes Chromium, Chrome, and Firefox zip artifacts to the GitHub Releases page.
+- If you change build scripts, manifests, or release packaging, confirm the workflow output remains consistent.
+
+## Data Handling And Compliance
+
+- Keep Firefox data-collection declarations accurate when Firefox manifest behavior changes.
+- Do not introduce telemetry, data export, or third-party transmission behavior without updating documentation and any required consent or disclosure flow.
+- Contributions should support lawful, ethical use and should not encourage violating TikTok Terms of Service or creator rights.
+
+## Reporting Security Issues
+
+- If you find a security issue, do not post exploit details in a public issue.
+- Open a minimal issue requesting a private contact path, or contact the maintainer directly if you already have a trusted channel.

--- a/LEGAL.md
+++ b/LEGAL.md
@@ -1,0 +1,42 @@
+# Legal And Responsible Use Notice
+
+This repository and its release artifacts are provided as open source software for educational, research, interoperability, archival, accessibility, and other lawful purposes.
+
+## No Endorsement Of Misuse
+
+- The maintainers do not endorse or encourage misuse of this project.
+- This project must not be used to infringe copyright, violate privacy, breach contracts, bypass access controls, abuse a platform, or interfere with creator rights.
+- Use of this software is your responsibility.
+
+## Platform Terms And User Responsibility
+
+- You are responsible for ensuring your use complies with applicable law, regulations, contracts, creator permissions, and platform rules.
+- That includes TikTok's Terms of Service, community rules, intellectual property policies, and any limits that apply to your account or the content you access.
+- Using this software does not grant you any right to copy, distribute, archive, or reuse content that you do not otherwise have permission to access or save.
+
+## No Affiliation
+
+- This project is an independent open source effort.
+- It is not affiliated with, endorsed by, sponsored by, or approved by TikTok, ByteDance, or any related company.
+
+## Trademark Notice
+
+- TikTok and related names, logos, and brand features are the property of their respective owners.
+- References to TikTok in this repository are used only to identify compatibility and describe the software's intended interoperability.
+- No claim of ownership over third-party trademarks is made.
+
+## Open Source License
+
+- Source code in this repository is licensed under the MIT License unless otherwise stated.
+- The open source license governs reuse of the code.
+- This notice adds project guidance about responsible use and trademark position, but it does not replace your obligation to obtain your own legal advice if needed.
+
+## Release Artifacts
+
+- Official release builds are distributed through the GitHub Releases page for this repository.
+- If you redistribute modified builds or forks, do not imply endorsement by the original maintainer, TikTok, or ByteDance.
+
+## No Legal Advice
+
+- This file is a practical project notice, not legal advice.
+- If you need advice on copyright, privacy, consumer law, contract compliance, or platform terms, consult qualified counsel in the relevant jurisdiction.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arsene I. Muhire
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Easy TikTok Video Downloader
+
+Easy TikTok Video Downloader is an open source browser extension for saving supported TikTok videos and bulk-download surfaces in browsers supported by this repository.
+
+## Open Source
+
+- This project is released under the MIT License. See [LICENSE](LICENSE).
+- Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
+- Responsible-use and platform/trademark disclaimers live in [LEGAL.md](LEGAL.md).
+
+## Releases
+
+- Release artifacts are published on the GitHub Releases page: https://github.com/datazinc/easy-tiktok-video-downloader/releases
+- The automated release workflow on `main` publishes these zip assets:
+- `easy-tiktok-video-downloader-v<version>-chromium.zip`
+- `easy-tiktok-video-downloader-v<version>-chrome.zip`
+- `easy-tiktok-video-downloader-v<version>-firefox.zip`
+
+## Local Development
+
+### Prerequisites
+
+- Node.js 20 or newer is recommended.
+- npm is used for dependency management and build scripts.
+
+### Setup
+
+```bash
+npm ci
+npm run setup:hooks
+```
+
+### Build Commands
+
+```bash
+npm run build:prod
+npm run buildff:prod
+npm run verify:versions
+```
+
+## Responsible Use
+
+- This project is maintained for educational, research, interoperability, archival, accessibility, and other lawful uses.
+- The maintainers do not endorse misuse of the software, including copyright infringement, privacy violations, unauthorized copying, abusive automation, or attempts to evade platform restrictions.
+- You are responsible for using this project ethically and in compliance with applicable law, creator rights, privacy obligations, and TikTok's Terms of Service and related policies.
+- Use this tool only for content and accounts you are authorized to access and save.
+
+## Trademark Notice
+
+- TikTok is a trademark of ByteDance Ltd. and/or its affiliates.
+- This project is not affiliated with, endorsed by, sponsored by, or approved by TikTok or ByteDance.
+- Any reference to TikTok is used only to describe compatibility and intended interoperability.
+
+## Contributing
+
+- Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+- If your change affects user-facing behavior, permissions, data handling, release packaging, or platform compliance, update the relevant documentation in the same change.

--- a/src/modules/utils/html.js
+++ b/src/modules/utils/html.js
@@ -1,5 +1,254 @@
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+const ALLOWED_HTML_TAGS = new Set([
+  "a",
+  "b",
+  "blockquote",
+  "br",
+  "code",
+  "details",
+  "div",
+  "em",
+  "h2",
+  "h3",
+  "li",
+  "ol",
+  "p",
+  "section",
+  "span",
+  "strong",
+  "summary",
+  "ul",
+]);
+
+const ALLOWED_SVG_TAGS = new Set([
+  "svg",
+  "g",
+  "path",
+  "line",
+  "polyline",
+  "polygon",
+  "rect",
+  "circle",
+]);
+
+const VOID_TAGS = new Set(["br"]);
+const GLOBAL_ATTRIBUTES = new Set(["class", "id", "role", "style", "title"]);
+const LINK_ATTRIBUTES = new Set(["href", "target", "rel"]);
+const SVG_ATTRIBUTES = new Set([
+  "aria-hidden",
+  "cx",
+  "cy",
+  "d",
+  "fill",
+  "focusable",
+  "height",
+  "points",
+  "r",
+  "rect",
+  "rx",
+  "stroke",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-width",
+  "viewbox",
+  "width",
+  "x",
+  "x1",
+  "x2",
+  "xmlns",
+  "y",
+  "y1",
+  "y2",
+]);
+
+const HTML_ENTITY_MAP = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: "\u00A0",
+  quot: '"',
+};
+
+function decodeHtmlEntities(value) {
+  return String(value ?? "").replace(
+    /&(#39|#x27|#x2f|#47|#x3d|#61|[a-z]+);/gi,
+    (match, entity) => {
+      const normalized = entity.toLowerCase();
+
+      if (normalized.startsWith("#x")) {
+        const codePoint = Number.parseInt(normalized.slice(2), 16);
+        return Number.isFinite(codePoint)
+          ? String.fromCodePoint(codePoint)
+          : match;
+      }
+
+      if (normalized.startsWith("#")) {
+        const codePoint = Number.parseInt(normalized.slice(1), 10);
+        return Number.isFinite(codePoint)
+          ? String.fromCodePoint(codePoint)
+          : match;
+      }
+
+      return HTML_ENTITY_MAP[normalized] ?? match;
+    },
+  );
+}
+
+function isAllowedTag(tagName) {
+  return ALLOWED_HTML_TAGS.has(tagName) || ALLOWED_SVG_TAGS.has(tagName);
+}
+
+function isSvgTag(tagName) {
+  return ALLOWED_SVG_TAGS.has(tagName);
+}
+
+function isAllowedAttribute(tagName, attrName) {
+  if (attrName.startsWith("on")) {
+    return false;
+  }
+
+  if (attrName.startsWith("aria-") || attrName.startsWith("data-")) {
+    return true;
+  }
+
+  if (GLOBAL_ATTRIBUTES.has(attrName)) {
+    return true;
+  }
+
+  if (tagName === "a" && LINK_ATTRIBUTES.has(attrName)) {
+    return true;
+  }
+
+  if (isSvgTag(tagName) && SVG_ATTRIBUTES.has(attrName)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isSafeHref(value) {
+  if (!value) {
+    return true;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized.startsWith("#") ||
+    normalized.startsWith("/") ||
+    normalized.startsWith("http://") ||
+    normalized.startsWith("https://") ||
+    normalized.startsWith("mailto:") ||
+    normalized.startsWith("tel:")
+  );
+}
+
+function parseAttributes(rawAttributes) {
+  const attributes = [];
+  const attrPattern =
+    /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+  let match = null;
+
+  while ((match = attrPattern.exec(rawAttributes))) {
+    attributes.push({
+      name: match[1],
+      value: match[2] ?? match[3] ?? match[4] ?? "",
+    });
+  }
+
+  return attributes;
+}
+
+function createElementForTag(tagName, parentNode) {
+  const insideSvg = parentNode?.namespaceURI === SVG_NAMESPACE;
+  if (insideSvg || isSvgTag(tagName)) {
+    return document.createElementNS(SVG_NAMESPACE, tagName);
+  }
+
+  return document.createElement(tagName);
+}
+
+function normalizeAttributeName(attrName) {
+  return attrName.toLowerCase() === "viewbox" ? "viewBox" : attrName;
+}
+
 export function createHtmlFragment(html) {
-  return document.createRange().createContextualFragment(String(html ?? ""));
+  const fragment = document.createDocumentFragment();
+  const nodeStack = [fragment];
+  const tagStack = [];
+  const tokens = String(html ?? "").match(/<[^>]+>|[^<]+/g) || [];
+
+  for (const token of tokens) {
+    if (!token) {
+      continue;
+    }
+
+    if (token.startsWith("</")) {
+      const closeMatch = token.match(/^<\s*\/\s*([a-zA-Z0-9:-]+)/);
+      if (!closeMatch) {
+        continue;
+      }
+
+      const closingTag = closeMatch[1].toLowerCase();
+      while (tagStack.length > 0) {
+        const lastTag = tagStack.pop();
+        nodeStack.pop();
+        if (lastTag === closingTag) {
+          break;
+        }
+      }
+      continue;
+    }
+
+    if (token.startsWith("<")) {
+      const openMatch = token.match(/^<\s*([a-zA-Z0-9:-]+)([^>]*)>/);
+      if (!openMatch) {
+        continue;
+      }
+
+      const tagName = openMatch[1].toLowerCase();
+      if (!isAllowedTag(tagName)) {
+        continue;
+      }
+
+      const currentParent = nodeStack[nodeStack.length - 1];
+      const element = createElementForTag(tagName, currentParent);
+      const rawAttributes = openMatch[2] || "";
+
+      for (const attribute of parseAttributes(rawAttributes)) {
+        const attrName = attribute.name.toLowerCase();
+        if (!isAllowedAttribute(tagName, attrName)) {
+          continue;
+        }
+
+        const decodedValue = decodeHtmlEntities(attribute.value);
+        if (attrName === "href" && !isSafeHref(decodedValue)) {
+          continue;
+        }
+
+        element.setAttribute(
+          normalizeAttributeName(attribute.name),
+          decodedValue,
+        );
+      }
+
+      currentParent.appendChild(element);
+
+      const selfClosing = VOID_TAGS.has(tagName) || /\/\s*>$/.test(token);
+      if (!selfClosing) {
+        nodeStack.push(element);
+        tagStack.push(tagName);
+      }
+      continue;
+    }
+
+    nodeStack[nodeStack.length - 1].appendChild(
+      document.createTextNode(decodeHtmlEntities(token)),
+    );
+  }
+
+  return fragment;
 }
 
 export function replaceElementHtml(element, html) {


### PR DESCRIPTION
This pull request introduces foundational open source documentation and improves HTML sanitization in the codebase. The most important changes are the addition of legal, contribution, and project documentation files, as well as a comprehensive rewrite of the `createHtmlFragment` utility to safely parse and sanitize HTML and SVG content.

**Documentation and Licensing:**

* Added `CONTRIBUTING.md` with clear guidelines for contributions, development setup, validation, pull requests, release notes, compliance, and security issue reporting.
* Added `LEGAL.md` outlining responsible use, platform terms, trademark notice, licensing, and legal disclaimers.
* Added `LICENSE` file applying the MIT License to the project.
* Updated `README.md` to include project description, release process, responsible use, trademark notice, and contribution instructions.

**Security and HTML Handling:**

* Rewrote `createHtmlFragment` in `src/modules/utils/html.js` to implement strict HTML/SVG sanitization, allowing only a safe subset of tags and attributes, decoding HTML entities, and blocking unsafe links and event handlers. This mitigates XSS and injection risks.